### PR TITLE
Direct copy readme files

### DIFF
--- a/src/angel-docs/main.py
+++ b/src/angel-docs/main.py
@@ -73,6 +73,11 @@ def build_docs(raw_sources: List[str], raw_outdir: str):
         if "<tab>" in content:
             safe_content = content.replace("<tab>", "tab")
             file.write_text(safe_content)
+    # Copy readmes
+    for file in files:
+        if file.endswith(".md"):
+            output_file = outdir.joinpath(file)
+            shutil.copy(file, str(output_file))
 
 
 def resolve_file_sources(raw_sources: List[str]) -> List[str]:

--- a/src/angel-docs/tests/conftest.py
+++ b/src/angel-docs/tests/conftest.py
@@ -1,0 +1,31 @@
+"""
+* Project Name: AngelDocs
+* File Name: conftest.py
+* Programmer: Kai Prince
+* Date: Tue, Apr 13, 2021
+* Description: This file contains config for tests.
+"""
+import os
+import pytest
+import shutil
+
+
+@pytest.fixture(autouse=True)
+def test_files_dir(tmp_path, request):
+    """ Copy mock files to temp directory. """
+    path_of_current_module = request.fspath.dirname
+    FILES_FOLDER = os.path.join(path_of_current_module, "sample")
+
+    # Copy files in test uploads folder to temp directory
+    shutil.copytree(FILES_FOLDER, tmp_path, dirs_exist_ok=True)
+
+    yield tmp_path
+
+    # Teardown
+
+
+@pytest.fixture(scope="function")
+def change_test_dir(request, tmp_path):
+    os.chdir(tmp_path)
+    yield os.chdir
+    os.chdir(request.config.invocation_dir)

--- a/src/angel-docs/tests/sample/project/module/Readme.md
+++ b/src/angel-docs/tests/sample/project/module/Readme.md
@@ -1,0 +1,1 @@
+# This is a test

--- a/src/angel-docs/tests/test_copy_readme_files.py
+++ b/src/angel-docs/tests/test_copy_readme_files.py
@@ -1,0 +1,25 @@
+"""
+* Project Name: AngelDocs
+* File Name: test_copy_readme_files.py
+* Programmer: Kai Prince
+* Date: Tue, Apr 13, 2021
+* Description: This file contains tests for the "Copy readme files" feature.
+"""
+
+from main import build_docs
+from pathlib import Path
+
+
+def test_copy_readme_file(change_test_dir):
+    """ Copies all .md files from the source folder to the output. """
+    # Arrange
+
+    sources = ["project"]
+    output_dir = "output"
+
+    # Act
+    build_docs(sources, output_dir)
+
+    # Assert
+    assert Path("output/project/module/Readme.md").exists()
+    assert Path("output/project/module/Readme.md").read_text() == "# This is a test\n"

--- a/src/angel-docs/tests/test_folder_structure.py
+++ b/src/angel-docs/tests/test_folder_structure.py
@@ -5,32 +5,9 @@
 * Date: Tue, Mar 23, 2021
 * Description: This file contains tests for the nested folder structure feature.
 """
-import os
 from pathlib import Path
-import shutil
 import pytest
 from main import build_docs
-
-
-@pytest.fixture(autouse=True)
-def test_files_dir(tmp_path, request):
-    """ Copy mock files to temp directory. """
-    path_of_current_module = request.fspath.dirname
-    FILES_FOLDER = os.path.join(path_of_current_module, "sample")
-
-    # Copy files in test uploads folder to temp directory
-    shutil.copytree(FILES_FOLDER, tmp_path, dirs_exist_ok=True)
-
-    yield tmp_path
-
-    # Teardown
-
-
-@pytest.fixture(scope="function")
-def change_test_dir(request, tmp_path):
-    os.chdir(tmp_path)
-    yield os.chdir
-    os.chdir(request.config.invocation_dir)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview

All .md files will now be copied to their respective folders in the generated site.

### Reason for change

Previously, empty .md files were being generated by pycco. This would leave blank .md files in the generated site.
Also this enables the planned feature of writing guide docs in the source.

### Changes summarized

- Copy all .md files to output folder.
- Add tests.
- Move test fixtures to conftest.

### Suggested future tasks

None. 

## Pre-merge checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job
