### PR TITLE
Fix deep sidebar links unhandled.

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -86,11 +86,19 @@ a.sidebar-link-item:hover {
   > .sidebar-link
   > .sidebar-links
   > .sidebar-link
-  > .sidebar-link-item
-  + .sidebar-link-item {
+  > .sidebar-links
+  > .sidebar-link
+  .sidebar-link-item {
   display: block;
   padding: 0.3rem 1.5rem 0.3rem 4.5rem;
   line-height: 1.4;
   font-size: 0.9rem;
   font-weight: 400;
+}
+
+p.sidebar-link-item {
+  font-weight: 600 !important;
+}
+p.sidebar-link-item:after {
+  content: "/";
 }

--- a/src/angel-docs/main.py
+++ b/src/angel-docs/main.py
@@ -44,7 +44,7 @@ def main():
         dest="ignore_paths",
         default=[],
         action="append",
-        help="Glob pattern to ignore (e.g. project/modules/**)",
+        help="Glob pattern to ignore (e.g. project/modules/**/*)",
     )
     parser.add_argument("files", nargs="*", type=str, help="Files to process")
     args = parser.parse_args()


### PR DESCRIPTION
## Overview

Sidebar links now hit max padding at 5 levels.

### Reason for change

![image](https://user-images.githubusercontent.com/34746763/115583027-816b8200-a297-11eb-86e5-3280922ddba1.png)

- Previously, links that were above 4 levels deep did not have a matching CSS rule, and looked wonky.

### Changes summarized

- Add CSS rule to all (recursive) descendants after 5 levels.
- Highlight folders so they are not mistaken for pages.

### Suggested future tasks

- Apply recursive CSS rules so there is no need for max padding.

## Pre-merge checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job
