### PR TITLE
Fix cp command in action.

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -18,4 +18,4 @@ yarn --cwd /app/docs build
 
 
 # Copy site to output folder
-cp -f -R /app/docs/.vitepress/dist $FOLDER
+cp -f -R -v /app/docs/.vitepress/dist "$FOLDER"

--- a/action.sh
+++ b/action.sh
@@ -18,4 +18,4 @@ yarn --cwd /app/docs build
 
 
 # Copy site to output folder
-cp -f -R -v /app/docs/.vitepress/dist "$FOLDER"
+cp -f -R -v /app/docs/.vitepress/dist/* "$FOLDER"

--- a/action.sh
+++ b/action.sh
@@ -18,4 +18,5 @@ yarn --cwd /app/docs build
 
 
 # Copy site to output folder
+mkdir -p "$FOLDER"
 cp -f -R -v /app/docs/.vitepress/dist/* "$FOLDER"


### PR DESCRIPTION
## Overview

Github Action now correctly overwrites existing files in the output folder.
Verbose output has also been enabled.

### Reason for change

- When running the action twice, it would create a nested folder, i.e. `dist/dist`.

### Changes summarized

- Surround `$FOLDER` with quotes. (Just in case.)
- Add verbose flag
- Copy by files instead of by folder.

### Suggested future tasks

None.

## Pre-merge checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job
